### PR TITLE
Fix non-existing platform warning

### DIFF
--- a/FlatNodes.uplugin
+++ b/FlatNodes.uplugin
@@ -20,7 +20,7 @@
 			"Name": "FlatNodes",
 			"Type": "Editor",
 			"LoadingPhase": "Default",
-			"WhitelistPlatforms": [ "Win64", "Win32", "Mac", "Linux" ]
+			"WhitelistPlatforms": [ "Win64", "Mac", "Linux" ]
 
 		}
 	]


### PR DESCRIPTION
Fix current warning `Unknown platform Win32 while parsing allow list for module descriptor FlatNodes`.