### PR TITLE
Make plugin work with all 4.27 versions

### DIFF
--- a/FlatNodes.uplugin
+++ b/FlatNodes.uplugin
@@ -10,7 +10,7 @@
 	"FileVersion": 3,
 	"Version": 1,
 	"VersionName": "1.0",
-	"EngineVersion": "4.27.0",
+	"EngineVersion": "4.27",
 	"CanContainContent": true,
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,


### PR DESCRIPTION
Currently, the editor will complain about this plugin on launch if the version isn't strictly 4.27.0.